### PR TITLE
metadata: Fix license metadata for NuGet publishing.

### DIFF
--- a/src/OpenPolicyAgent.Ucast.Linq/OpenPolicyAgent.Ucast.Linq.csproj
+++ b/src/OpenPolicyAgent.Ucast.Linq/OpenPolicyAgent.Ucast.Linq.csproj
@@ -11,7 +11,7 @@
     <NoWarn>1591</NoWarn>
     <RepositoryUrl>https://github.com/open-policy-agent/ucast-linq</RepositoryUrl>
     <PackageProjectUrl>https://github.com/open-policy-agent/ucast-linq</PackageProjectUrl>
-    <PackageLicenseExpression>APACHE-2.0</PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This PR fixes a metadata issue: the package license expression filed in our .csproj for the package.

The old one, `APACHE-2.0` is not recognized. The new one, `Apache-2.0` should be.

-----

Previously, we'd get the exciting warning during artifact packing:
```
Warning: /usr/share/dotnet/sdk/8.0.413/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5124: The license identifier 'APACHE-2.0' is not recognized by the current toolset. [/home/runner/work/ucast-linq/ucast-linq/src/OpenPolicyAgent.Ucast.Linq/OpenPolicyAgent.Ucast.Linq.csproj]
```
Which would then explode in flames in the package publishing step:
```
Pushing OpenPolicyAgent.Ucast.Linq.0.6.0.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  BadRequest https://www.nuget.org/api/v2/package/ 394ms
error: Response status code does not indicate success: 400 (Invalid license metadata: The license identifier(s) 'APACHE-2.0' is(are) not recognized by the current toolset.).
Error: Process completed with exit code 1.
```

### :athletic_shoe: How to test

 - Merge this metadata fix, try the manual publish workflow again. :disappointed: 

### :chains: Related Resources

